### PR TITLE
feat: Add sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://swedenupdate.com/</loc>
+    <lastmod>2025-10-19</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Adds a `sitemap.xml` file to the `public/` directory to improve SEO.

The sitemap contains a single entry for the root URL, as the application is a single-page app where navigation and filtering do not change the URL path.